### PR TITLE
prevent joining an already existed response topic

### DIFF
--- a/rpc.go
+++ b/rpc.go
@@ -91,7 +91,7 @@ func NewTopic(ctx context.Context, ps *pubsub.PubSub, host peer.ID, topic string
 	}
 	t.resTopic, err = newTopic(ctx, ps, host, responseTopic(topic, host), true)
 	if err != nil {
-		t.cancel()
+		_ = t.Close()
 		return nil, fmt.Errorf("creating response topic: %v", err)
 	}
 	t.resTopic.eventHandler = t.resEventHandler
@@ -107,6 +107,7 @@ func newTopic(ctx context.Context, ps *pubsub.PubSub, host peer.ID, topic string
 
 	handler, err := top.EventHandler()
 	if err != nil {
+		_ = top.Close()
 		return nil, fmt.Errorf("getting topic handler: %v", err)
 	}
 
@@ -114,6 +115,8 @@ func newTopic(ctx context.Context, ps *pubsub.PubSub, host peer.ID, topic string
 	if subscribe {
 		sub, err = top.Subscribe()
 		if err != nil {
+			handler.Cancel()
+			_ = top.Close()
 			return nil, fmt.Errorf("subscribing to topic: %v", err)
 		}
 	}


### PR DESCRIPTION
With re-publishing, this can be seen in bidbot frequently. This is a fix.
```
2021-08-04T16:37:33.488+0200  ERROR  mpeer/pubsub  pubsub/pubsub.go:283  creating response topic: joining topic: topic already exists
2021-08-04T16:38:17.039+0200  ERROR  mpeer/pubsub  pubsub/pubsub.go:283  creating response topic: joining topic: topic already exists
2021-08-04T16:38:46.664+0200  ERROR  mpeer/pubsub  pubsub/pubsub.go:283  creating response topic: joining topic: topic already exists
2021-08-04T16:40:21.257+0200  ERROR  mpeer/pubsub  pubsub/pubsub.go:283  creating response topic: joining topic: topic already exists
```